### PR TITLE
Corrected the typical English usage of these.

### DIFF
--- a/Gender.xml
+++ b/Gender.xml
@@ -1,6 +1,7 @@
 <string-array name="gender">
-	<item>Man</item>
-	<item>Woman</item>
+	<item>Male</item>
+	<item>Female</item>
+	<item>Intersex</item>
 	<item>Transgender</item>
 	<item>Questioning</item>
 	<item>Not Applicable</item>


### PR DESCRIPTION
Man -> Male (does not imply adulthood)
Woman -> Female (does not imply adulthood)

Added "Intersex" as an option (I have a student who was born with both male and female organs, and this is what I'm told by different groups is the currently correct term for this).

Would like to see this added to the main repo.